### PR TITLE
wrap examples

### DIFF
--- a/test/fixtures/wrap-each.pug
+++ b/test/fixtures/wrap-each.pug
@@ -1,0 +1,92 @@
+//- @pugdoc
+  name: Wrap examples each object one level
+  expected: <div><span>1</span></div><div><span>2</span></div>
+  wrapEach: |
+    div
+      block
+  examples:
+    -
+      name: Foo 1
+      example: |
+        span 1
+    -
+      name: Foo 2
+      example: |
+        span 2
+
+div
+
+//- @pugdoc
+  name: Wrap examples each object two levels
+  expected: <div><p><span>1</span></p></div><div><p><span>2</span></p></div>
+  wrapEach: |
+    div
+      p
+        block
+  examples:
+    -
+      name: Foo 1
+      example: |
+        span 1
+    -
+      name: Foo 2
+      example: |
+        span 2
+
+div
+
+//- @pugdoc
+  name: Wrap examples each simple one level
+  expected: <div><span>1</span></div><div><span>2</span></div>
+  wrapEach: |
+    div
+      block
+  examples:
+    - | span 1
+    - | span 2
+    
+div
+
+//- @pugdoc
+  name: Wrap examples each simple two levels
+  expected: <div><p><span>1</span></p></div><div><p><span>2</span></p></div>
+  wrapEach: |
+    div
+      p
+        block
+  examples:
+    - | span 1
+    - | span 2
+    
+div
+
+//- @pugdoc
+  name: Wrap examples each before
+  expected: <div>before</div><div><p><span>1</span></p></div><div><p><span>2</span></p></div><div>after</div>
+  wrapEach: |
+    div before
+    div
+      p
+        block
+    div after
+  examples:
+    - | span 1
+    - | span 2
+    
+div
+
+//- @pugdoc
+  name: Wrap examples each mixin
+  expected: <hello>1</hello><hello>2</hello>
+  wrapEach: |
+    include ./hello
+    div
+      p
+        block
+    div after
+  examples:
+    - | +hello(1)
+    - | +hello(2)
+    
+mixin foo(str)
+  div #{str}

--- a/test/fixtures/wrap.pug
+++ b/test/fixtures/wrap.pug
@@ -1,0 +1,72 @@
+//- @pugdoc
+  name: Wrap example one level
+  expected: <div><span></span></div>
+  wrap: |
+    div
+      block
+  example: |
+    span
+
+div
+
+//- @pugdoc
+  name: Wrap example one level, before/after
+  expected: <div>before</div><div><span></span></div><div>after</div>
+  wrap: |
+    div before
+    div
+      block
+    div after
+  example: |
+    span
+
+div
+
+//- @pugdoc
+  name: Wrap example two levels
+  expected: <div><p><span></span></p></div>
+  wrap: |
+    div
+      p
+        block
+  example: |
+    span
+
+div
+
+//- @pugdoc
+  name: Wrap examples one level
+  expected: <div><span>1</span><span>2</span></div>
+  wrap: |
+    div
+      block
+  examples:
+    -
+      name: Foo 1
+      example: |
+        span 1
+    -
+      name: Foo 2
+      example: |
+        span 2
+
+div
+
+//- @pugdoc
+  name: Wrap examples two levels
+  expected: <div><p><span>1</span><span>2</span></p></div>
+  wrap: |
+    div
+      p
+        block
+  examples:
+    -
+      name: Foo 1
+      example: |
+        span 1
+    -
+      name: Foo 2
+      example: |
+        span 2
+
+div

--- a/test/wip.js
+++ b/test/wip.js
@@ -2,15 +2,8 @@ const fs = require("fs");
 const pugDoc = require("../index");
 const pugDocParser = require("../lib/parser");
 
-// pugDoc({
-//   input: ["./test/fixtures/examples-objects.pug"],
-// });
+const src = fs.readFileSync("./test/fixtures/wrap.pug").toString();
+const doc = pugDocParser.getPugdocDocuments(src, "./test/fixtures/wrap.pug");
+console.log("---");
 
-const src = fs.readFileSync("./test/fixtures/error.pug").toString();
-const doc = pugDocParser.getPugdocDocuments(
-  src,
-  "./test/fixtures/before-after.pug"
-);
-// console.log("---");
-
-// console.log(doc[0]);
+console.log(doc);


### PR DESCRIPTION
add the ability to wrap pug code around examples, for each example separately and globally:

```pug
//- @pugdoc
  name: Foo
  wrap: |
    div.wrap
  examples:
    - | span 1
    - | span 2
```

should output:

```html
<div class="wrap"><span>1</span><span>2</span></div>
```

Question: What should the wrap option do for individual examples? Ignore? Or also wrap?
(Maybe a solution for the grouped-example could be to add a separator option?)

---

```pug
//- @pugdoc
  name: Foo
  wrapEach: |
    div.wrap
  examples:
    - | span 1
    - | span 2
```

should output:

```html
<div class="wrap"><span>1</span></div><div class="wrap"><span>2</span></div>
```