### PR TITLE
⚡️ Feature/cache

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-"use strict";
 
 const meow = require("meow");
 const pugDoc = require("./index");
@@ -11,16 +10,26 @@ const cli = meow(`
     "",
     "Options",
     "  --output    Set output json file"
+    "  --silent    No terminal output"
   `);
+
+console.time("Finished Pug-doc");
 
 const pd = new pugDoc({
   input: cli.input[0],
   output: cli.flags.output,
+  useCache: Boolean(cli.flags.useCache),
 });
 
-process.stdin.pipe(pd).pipe(JSONStream.stringify()).pipe(process.stdout);
+const stream = process.stdin.pipe(pd).pipe(JSONStream.stringify());
+
+if (!cli.flags.silent) {
+  stream.pipe(process.stdout);
+}
 
 pd.on("complete", function () {
+  console.log("");
+  console.timeEnd("Finished Pug-doc");
   process.exit();
 });
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ function pugDoc(options) {
         }
 
         // make dict for fragments
+
         if (cur.fragments) {
+          console.log(typeof cur.fragments);
           cur.fragmentsDict = cur.fragments.reduce((acc2, cur2, i) => {
             if (!cur2.meta.name) {
               process.stderr.write(
@@ -93,11 +95,11 @@ function pugDoc(options) {
               );
             }
 
-            acc2[cur2.meta.name] = cur2;
+            acc2[cur2.meta.name] = { ...cur2 };
             return acc2;
           }, {});
 
-          cur.fragments = cur.fragmentsDict;
+          cur.fragments = { ...cur.fragmentsDict };
           delete cur.fragmentsDict;
         }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-"use strict";
-/* globals require, module */
-
 const fs = require("fs");
 const path = require("path");
 const mkdirp = require("mkdirp");
@@ -32,6 +29,7 @@ function pugDoc(options) {
       output: null,
       locals: {},
       complete: function () {},
+      useCache: true,
     },
     options
   );
@@ -53,6 +51,62 @@ function pugDoc(options) {
       cb();
     }
   );
+
+  // make lookup cache
+  let cache = {};
+  if (options.useCache) {
+    let cachedOutputJSON = null;
+    if (options.output) {
+      try {
+        cachedOutputJSON = require(`${__dirname}/${options.output}`);
+      } catch (err) {}
+    }
+
+    if (cachedOutputJSON) {
+      // make dict for documents
+      cache = cachedOutputJSON.reduce((acc, cur, i) => {
+        if (!cur.meta.name) {
+          process.stderr.write(
+            `\nPug-doc error: No document name given in ${cur.file}\n`
+          );
+        }
+
+        if (cur.meta.name && acc[cur.meta.name]) {
+          process.stderr.write(
+            `\n\nPug-doc error: Duplicate document name: ‹${cur.meta.name}› in ${cur.file}`
+          );
+          process.stderr.write(`\n${JSON.stringify(cur.meta, null, 2)}`);
+        }
+
+        // make dict for fragments
+        if (cur.fragments) {
+          cur.fragmentsDict = cur.fragments.reduce((acc2, cur2, i) => {
+            if (!cur2.meta.name) {
+              process.stderr.write(
+                `\nPug-doc error: No example name given at ‹${cur.meta.name}› in ${cur.file}\n`
+              );
+            }
+
+            if (cur2.meta.name && acc2[cur2.meta.name]) {
+              process.stderr.write(
+                `\n\nPug-doc error: Duplicate example name: ‹${cur2.meta.name}› at ${cur.meta.name} in ${cur.file}`
+              );
+            }
+
+            acc2[cur2.meta.name] = cur2;
+            return acc2;
+          }, {});
+
+          cur.fragments = cur.fragmentsDict;
+          delete cur.fragmentsDict;
+        }
+
+        acc[cur.meta.name] = cur;
+
+        return acc;
+      }, {});
+    }
+  }
 
   let output;
 
@@ -90,7 +144,8 @@ function pugDoc(options) {
       let pugDocDocuments = parser.getPugdocDocuments(
         files[file],
         file,
-        options.locals
+        options.locals,
+        cache
       );
       pugDocDocuments
         .filter(function (docItem) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -112,6 +112,9 @@ function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
     // because examples object becomes an array
     // would be a breaking change, but could bring a
     // large performance boost
+    // TODO: or store the YAML cache completely if cache is set and
+    // just diff the text? Would probably be fastest
+    // this would not be a breaking change
 
     // parse jsdoc style arguments list
     if (meta.arguments) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -116,6 +116,57 @@ function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
     // just diff the text? Would probably be fastest
     // this would not be a breaking change
 
+    // if: meta must be the same
+    // if: comment must be the same
+    // if: overall locals are the same
+
+    if (documentCache) {
+      // console.log(pugdocBlock);
+      // console.log(documentCache);
+      // console.log("---");
+
+      // TODO: this crashes…
+      // start again with caching?????
+
+      let cacheEquals = [];
+      if (pugdocBlock.comment === documentCache.comment) {
+        cacheEquals.push("comment");
+      } else {
+        console.log("comment is different");
+      }
+
+      // const metaWithoutExamples = { ...meta, examples: null };
+      // const cacheMetaWithoutExamples = {
+      //   ...documentCache.meta,
+      //   examples: null,
+      // };
+
+      // if (deepEqual(metaWithoutExamples, cacheMetaWithoutExamples)) {
+      //   cacheEquals.push("meta");
+      // } else {
+      //   console.log(meta);
+      //   console.log(documentCache.meta);
+
+      //   console.log("meta is different");
+      // }
+
+      if (pugdocBlock.code === documentCache.source) {
+        cacheEquals.push("code");
+      } else {
+        console.log("code is different");
+      }
+
+      if (cacheEquals.length === 2) {
+        // console.log("from cache: " + meta.name);
+        // console.log("---");
+
+        return documentCache;
+      }
+    }
+
+    console.log("new: " + meta.name);
+    console.log("---");
+
     // parse jsdoc style arguments list
     if (meta.arguments) {
       meta.arguments = meta.arguments.map(function (arg) {
@@ -186,7 +237,7 @@ function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
       meta.example = "";
     }
 
-    const cachedSourceEqual = documentCache && source === documentCache.source;
+    // const cachedSourceEqual = documentCache && source === documentCache.source;
 
     const obj = {
       // get meta
@@ -195,11 +246,10 @@ function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
       file: path.relative(".", filename),
       // get pug code block matching the comments indent
       source: source,
+      // store comment for caching
+      comment: pugdocBlock.comment,
       // get html output
-      output:
-        cachedSourceEqual && documentCache.output
-          ? documentCache.output
-          : compilePug(source, meta, filename, locals),
+      output: compilePug(source, meta, filename, locals),
     };
 
     // remove output if example = false
@@ -213,31 +263,31 @@ function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
         let output;
 
         // check cached example
-        if (
-          documentCache &&
-          documentCache.fragments &&
-          subexample.name &&
-          documentCache.fragments[subexample.name]
-        ) {
-          const cachedExample = documentCache.fragments[subexample.name];
-          if (
-            cachedSourceEqual &&
-            cachedExample &&
-            deepEqual(subexample, cachedExample.meta)
-          ) {
-            output = cachedExample.output;
-          }
-        }
+        // if (
+        //   documentCache &&
+        //   documentCache.fragments &&
+        //   subexample.name &&
+        //   documentCache.fragments[subexample.name]
+        // ) {
+        //   const cachedExample = documentCache.fragments[subexample.name];
+        //   if (
+        //     cachedSourceEqual &&
+        //     cachedExample &&
+        //     deepEqual(subexample, cachedExample.meta)
+        //   ) {
+        //     output = cachedExample.output;
+        //   }
+        // }
 
-        if (!output) {
-          output = compilePug(source, subexample, filename, locals);
-        }
+        // if (!output) {
+        //   output = compilePug(source, subexample, filename, locals);
+        // }
 
         return {
           // get meta
           meta: subexample,
           // get html output
-          output: output,
+          output: compilePug(source, subexample, filename, locals),
         };
       });
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,5 @@
 const pug = require("pug");
+const deepEqual = require("deep-equal");
 const pugRuntimeWrap = require("pug-runtime/wrap");
 
 const path = require("path");
@@ -101,10 +102,16 @@ function extractPugdocBlocks(templateSrc) {
  * @param filename {string}
  */
 
-function getPugdocDocuments(templateSrc, filename, locals) {
+function getPugdocDocuments(templateSrc, filename, locals, cache = {}) {
   return extractPugdocBlocks(templateSrc).map(function (pugdocBlock) {
     const meta = parsePugdocComment(pugdocBlock.comment);
     const fragments = [];
+
+    const documentCache = cache[meta.name];
+    // TODO: Can't do a deep equal check here
+    // because examples object becomes an array
+    // would be a breaking change, but could bring a
+    // large performance boost
 
     // parse jsdoc style arguments list
     if (meta.arguments) {
@@ -176,6 +183,8 @@ function getPugdocDocuments(templateSrc, filename, locals) {
       meta.example = "";
     }
 
+    const cachedSourceEqual = documentCache && source === documentCache.source;
+
     const obj = {
       // get meta
       meta: meta,
@@ -184,7 +193,10 @@ function getPugdocDocuments(templateSrc, filename, locals) {
       // get pug code block matching the comments indent
       source: source,
       // get html output
-      output: compilePug(source, meta, filename, locals),
+      output:
+        cachedSourceEqual && documentCache.output
+          ? documentCache.output
+          : compilePug(source, meta, filename, locals),
     };
 
     // remove output if example = false
@@ -195,11 +207,34 @@ function getPugdocDocuments(templateSrc, filename, locals) {
     // add fragments
     if (fragments && fragments.length) {
       obj.fragments = fragments.map((subexample) => {
+        let output;
+
+        // check cached example
+        if (
+          documentCache &&
+          documentCache.fragments &&
+          subexample.name &&
+          documentCache.fragments[subexample.name]
+        ) {
+          const cachedExample = documentCache.fragments[subexample.name];
+          if (
+            cachedSourceEqual &&
+            cachedExample &&
+            deepEqual(subexample, cachedExample.meta)
+          ) {
+            output = cachedExample.output;
+          }
+        }
+
+        if (!output) {
+          output = compilePug(source, subexample, filename, locals);
+        }
+
         return {
           // get meta
           meta: subexample,
           // get html output
-          output: compilePug(source, subexample, filename, locals),
+          output: output,
         };
       });
     }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "JSONStream": "^1.3.5",
     "clean-whitespace": "^0.1.2",
+    "deep-equal": "^2.0.3",
     "detect-indent": "^6.0.0",
     "doctrine": "^3.0.0",
     "indented-code-block": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,37 +3,37 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
+  integrity sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==
   dependencies:
-    "@babel/highlight" "^7.8.3"
+    "@babel/highlight" "^7.10.1"
 
-"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
-  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+"@babel/helper-validator-identifier@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
+  integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
 
-"@babel/highlight@^7.8.3":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
-  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+"@babel/highlight@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.1.tgz#841d098ba613ba1a427a2b383d79e35552c38ae0"
+  integrity sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
+    "@babel/helper-validator-identifier" "^7.10.1"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.6.0", "@babel/parser@^7.9.6":
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.0.tgz#8eca3e71a73dd562c5222376b08253436bb4995b"
-  integrity sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
+  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
 "@babel/types@^7.6.1", "@babel/types@^7.9.6":
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.0.tgz#d47d92249e42393a5723aad5319035ae411e3e38"
-  integrity sha512-t41W8yWFyQFPOAAvPvjyRhejcLGnJTA3iRpFcDbEKwVJ3UnHQePFzLk8GagTsucJlImyNwrGikGsYURrWbQG8w==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
+  integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.5"
+    "@babel/helper-validator-identifier" "^7.10.1"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -56,9 +56,9 @@ JSONStream@^1.3.5:
     through ">=2.2.7 <3"
 
 acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 acorn@~4.0.2:
   version "4.0.13"
@@ -507,9 +507,9 @@ is-boolean-object@^1.0.0:
   integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
 is-date-object@^1.0.1, is-date-object@^1.0.2:
   version "1.0.2"
@@ -553,11 +553,11 @@ is-promise@^2.0.0:
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-regex@^1.0.3, is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   dependencies:
-    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 is-set@^2.0.1:
   version "2.0.1"
@@ -699,9 +699,9 @@ meow@^7.0.0:
     yargs-parser "^18.1.3"
 
 min-indent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
-  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 "minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
@@ -1376,9 +1376,9 @@ which-typed-array@^1.1.2:
     is-typed-array "^1.1.3"
 
 with@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/with/-/with-7.0.0.tgz#60b88622fb56482a5ba7fa8ebe1a880d7b64a6e3"
-  integrity sha512-XS51xsYITl5V0q0AcZG/lMPFBbCETHLjL7Tr6ZOmPGP3UkKBmwOKqLgAmenC5v8MHDcOudpNkO1CW0kpe7Oyag==
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/with/-/with-7.0.2.tgz#ccee3ad542d25538a7a7a80aad212b9828495bac"
+  integrity sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==
   dependencies:
     "@babel/parser" "^7.9.6"
     "@babel/types" "^7.9.6"


### PR DESCRIPTION
if there is a pugdoc output file, we could use that to speed things up:

# 1. Full pugdoc document 
Cache whole document and check if it's completely the same. In order to do this we would need to make the examples array an object to be able to do an equal check. Alternatively we could make a cache property with the complete yaml comment. This would result in larger output files (not sure if this is an issue), but could make for faster checks.

# 2. Compiled example
if the example is the same as cache and before, afterEach and beforeEach are the same, don't compile pug. In order to do this there would need to be more strict checking of example names.

# 3. Compiled fragment examples
if the fragments are the same as cache and before, afterEach and beforeEach are the same, don't compile fragment pug. In order to do this there would need to be more strict checking of subexample names.

- quick tests so far show that large code bases drop from around 10sec to 1.5sec.